### PR TITLE
fix(time/weather): fix freeze logic and dynamic weather countdown logic

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -84,10 +84,12 @@ CreateThread(function()
             Wait(0)
             local _, _, _, hours, minutes, _ = GetLocalTime()
             local newBaseTime = baseTime
-            if tick - (Config.RealTimeSync and 500 or 22) > tick then
+        
+            if GetGameTimer() - tick > (Config.RealTimeSync and 500 or 22) then
                 second = second + timeIncrement
                 tick = GetGameTimer()
             end
+            
             if freezeTime then
                 timeOffset = timeOffset + baseTime - newBaseTime
                 second = 0

--- a/server.lua
+++ b/server.lua
@@ -307,13 +307,8 @@ end, 'admin')
 
 -- THREAD LOOPS
 CreateThread(function()
-    local previous = 0
-    local realTimeFromApi = nil
-    local failedCount = 0
-
     while true do
         Wait(60000)                                           -- ⏱️ Sync server time every 1 minute with real time API. Falls back to OS time if failed.
-        local newBaseTime = os.time(os.date('!*t')) / 2 + 360 --Set the server time depending of OS time
         if Config.RealTimeSync then
             retrieveTimeFromApi(function(unixTime)
                 if unixTime then
@@ -344,11 +339,10 @@ end)
 
 CreateThread(function()
     while true do
-        Wait(60000)
+        Wait(60000) -- Check and decrement weather timer every 1 minute
         if newWeatherTimer > 0 then
             newWeatherTimer = newWeatherTimer - 1
         end
-        
         if newWeatherTimer == 0 then
             if Config.DynamicWeather then
                 nextWeatherStage()

--- a/server.lua
+++ b/server.lua
@@ -344,8 +344,11 @@ end)
 
 CreateThread(function()
     while true do
-        newWeatherTimer = newWeatherTimer - 1
-        Wait((1000 * 60) * Config.NewWeatherTimer)
+        Wait(60000)
+        if newWeatherTimer > 0 then
+            newWeatherTimer = newWeatherTimer - 1
+        end
+        
         if newWeatherTimer == 0 then
             if Config.DynamicWeather then
                 nextWeatherStage()


### PR DESCRIPTION
**Describe Pull request**
Fixed a critical math logic bug in `client.lua` (`tick - 22 > tick`) that was breaking time synchronization across players. Also fixed a thread loop interval issue in `server.lua` where the weather countdown was ticking down way slower than the configured `Config.NewWeatherTimer`.

**If your PR is to fix an issue mention that issue here**
These changes fix the issues where /time and /weather admin commands wouldn't update or sync properly.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
